### PR TITLE
Fix code scanning alert no. 10: LDAP query built from user-controlled sources

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/LdapService.java
+++ b/src/main/java/com/kalavit/javulna/services/LdapService.java
@@ -7,6 +7,8 @@ package com.kalavit.javulna.services;
 
 import com.kalavit.javulna.dto.LdapUserDto;
 import com.kalavit.javulna.springconfig.LdapConfig;
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Encoder;
 import java.util.Hashtable;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -52,7 +54,10 @@ public class LdapService {
         try {
             LdapUserDto ret = new LdapUserDto();
             DirContext ctx = initContext();
-            String filter = "(&(uid=" + uid + ") (userPassword=" + password + "))";
+            Encoder encoder = ESAPI.encoder();
+            String safeUid = encoder.encodeForLDAP(uid);
+            String safePassword = encoder.encodeForLDAP(password);
+            String filter = "(&(uid=" + safeUid + ") (userPassword=" + safePassword + "))";
 
             SearchControls ctls = new SearchControls();
             ctls.setSearchScope(SearchControls.SUBTREE_SCOPE);


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/10](https://github.com/Brook-5686/Java_2/security/code-scanning/10)

To fix the problem, we need to ensure that user input is properly sanitized and encoded before being used in the LDAP query. The best way to achieve this is by using a library that provides proper encoding for LDAP queries. In this case, we can use the OWASP ESAPI library to encode the user input before constructing the LDAP query.

1. Add the OWASP ESAPI library to the project dependencies.
2. Import the necessary classes from the ESAPI library.
3. Encode the user input using the `encodeForLDAP` method before constructing the LDAP query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
