### PR TITLE
Fix code scanning alert no. 6: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/RemotePasswordChangeService.java
+++ b/src/main/java/com/kalavit/javulna/services/RemotePasswordChangeService.java
@@ -34,6 +34,9 @@ public class RemotePasswordChangeService {
     public boolean changePassword(String psChangeXml) {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(new InputSource(new StringReader(psChangeXml)));
             String userName = doc.getElementsByTagName("userName").item(0).getFirstChild().getNodeValue();


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/6](https://github.com/Brook-5686/Java_2/security/code-scanning/6)

To fix the problem, we need to disable the parsing of external entities in the `DocumentBuilderFactory` instance. This can be done by setting specific features on the `DocumentBuilderFactory` to disallow DOCTYPE declarations and external entities. This change ensures that the XML parser is secure against XXE attacks.

The changes should be made in the `changePassword` method of the `RemotePasswordChangeService` class. Specifically, we need to set the following features on the `DocumentBuilderFactory` instance:
- `http://apache.org/xml/features/disallow-doctype-decl` to `true`
- `http://xml.org/sax/features/external-general-entities` to `false`
- `http://xml.org/sax/features/external-parameter-entities` to `false`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
