### PR TITLE
Fix code scanning alert no. 8: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/kalavit/javulna/springconfig/WebSecurityConfig.java
+++ b/src/main/java/com/kalavit/javulna/springconfig/WebSecurityConfig.java
@@ -80,9 +80,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .headers().frameOptions().disable().
-                and().csrf().disable()
-                .formLogin()
+                .headers().frameOptions().disable()
+                .and().formLogin()
                 .usernameParameter("username")
                 .successHandler(successHandler)
                 .failureHandler(failureHandler)


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/8](https://github.com/Brook-5686/Java_2/security/code-scanning/8)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `HttpSecurity` object. This can be done by removing the line that disables CSRF protection. By doing so, we ensure that the application is protected against CSRF attacks, which is the recommended practice for web applications accessed by browser clients.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
