### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/FileStorageService.java
+++ b/src/main/java/com/kalavit/javulna/services/FileStorageService.java
@@ -47,6 +47,10 @@ public class FileStorageService {
     }
     
     public Resource loadFileAsResource(String fileName) {
+        // Validate the fileName to ensure it does not contain path traversal sequences or invalid characters
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
         try {
             Path filePath = Paths.get(fileStorageDir, fileName);
             LOG.debug("gonna read file from {}" ,filePath.toString());


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/4](https://github.com/Brook-5686/Java_2/security/code-scanning/4)

To fix the problem, we need to validate the `fileName` parameter to ensure it does not contain any path traversal sequences or invalid characters. This can be done by checking for the presence of "..", "/", or "\\" in the `fileName`. If any of these characters are found, we should reject the input by throwing an `IllegalArgumentException`.

We will make the following changes:
1. Add validation for the `fileName` parameter in the `loadFileAsResource` method of `FileStorageService`.
2. Ensure that the `fileName` is safe to use in path expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
