### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/kalavit/javulna/services/FileStorageService.java
+++ b/src/main/java/com/kalavit/javulna/services/FileStorageService.java
@@ -35,9 +35,15 @@ public class FileStorageService {
 
     public String storeFile(MultipartFile file) {
         String fileName = StringUtils.cleanPath(file.getOriginalFilename());
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
         try {
             // Copy file to the target location (Replacing existing file with the same name)
-            Path targetLocation = Paths.get(fileStorageDir, fileName);
+            Path targetLocation = Paths.get(fileStorageDir).resolve(fileName).normalize().toAbsolutePath();
+            if (!targetLocation.startsWith(Paths.get(fileStorageDir).toAbsolutePath())) {
+                throw new IllegalArgumentException("Invalid filename");
+            }
             LOG.debug("gonna write file to {}" ,targetLocation.toString());
             Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
             return fileName;
@@ -47,8 +53,14 @@ public class FileStorageService {
     }
     
     public Resource loadFileAsResource(String fileName) {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
         try {
-            Path filePath = Paths.get(fileStorageDir, fileName);
+            Path filePath = Paths.get(fileStorageDir).resolve(fileName).normalize().toAbsolutePath();
+            if (!filePath.startsWith(Paths.get(fileStorageDir).toAbsolutePath())) {
+                throw new IllegalArgumentException("Invalid filename");
+            }
             LOG.debug("gonna read file from {}" ,filePath.toString());
             Resource resource = new UrlResource(filePath.toUri());
             if(resource.exists()) {


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/3](https://github.com/Brook-5686/Java_2/security/code-scanning/3)

To fix the problem, we need to validate the user-provided filename to ensure it does not contain any path traversal characters or sequences. This can be done by checking for the presence of "..", "/", or "\\" in the filename and rejecting the input if any are found. Additionally, we should ensure that the resolved path stays within the intended directory.

1. Add validation to check for path traversal characters in the filename.
2. Ensure the resolved path is within the intended directory.
3. Update the `storeFile` and `loadFileAsResource` methods in `FileStorageService.java` to include these validations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
