### PR TITLE
Fix code scanning alert no. 2: Failure to use secure cookies

### DIFF
--- a/src/main/java/com/kalavit/javulna/springconfig/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/kalavit/javulna/springconfig/CustomAuthenticationSuccessHandler.java
@@ -36,6 +36,7 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String userData = Base64.getEncoder().encodeToString(SerializationUtil.serialize(principal));
         Cookie cookie = new Cookie(USER_AUTHENTICATION_EXTRA_SECURITY, userData);
         cookie.setMaxAge(Integer.MAX_VALUE);
+        cookie.setSecure(true);
         return cookie;
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Java_2/security/code-scanning/2](https://github.com/Brook-5686/Java_2/security/code-scanning/2)

To fix the problem, we need to ensure that the 'secure' flag is set on the cookie before it is added to the response. This can be done by calling the `setSecure(true)` method on the `Cookie` object within the `createUserCookie` method. This change ensures that the cookie will only be sent over secure (HTTPS) connections, protecting it from being intercepted over unencrypted connections.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
